### PR TITLE
map key Y (in addition to key Z) to button Y, for international keyboards

### DIFF
--- a/snem/snesEmu.html
+++ b/snem/snesEmu.html
@@ -109,6 +109,7 @@
 	      case 67:     joy1=0x1000;break;
 	      case 68:     joy1=0x2000;break;
 	      case 90:     joy1=0x4000;break;
+	      case 89:     joy1=0x4000;break;
 	      case 88:     joy1=0x8000;break;
 	      }
 	      if(e.type=="keyup"){

--- a/snem/snesWW.html
+++ b/snem/snesWW.html
@@ -130,6 +130,7 @@
 	      case 67:     joy1=0x1000;break;
 	      case 68:     joy1=0x2000;break;
 	      case 90:     joy1=0x4000;break;
+	      case 89:     joy1=0x4000;break;
 	      case 88:     joy1=0x8000;break;
 	      }
 	      if(e.type=="keyup"){

--- a/snem/snesWW2.html
+++ b/snem/snesWW2.html
@@ -130,6 +130,7 @@
 	      case 67:     joy1=0x1000;break;
 	      case 68:     joy1=0x2000;break;
 	      case 90:     joy1=0x4000;break;
+	      case 89:     joy1=0x4000;break;
 	      case 88:     joy1=0x8000;break;
 	      }
 	      if(e.type=="keyup"){

--- a/snes9x/sdl/snes9x.html
+++ b/snes9x/sdl/snes9x.html
@@ -107,6 +107,7 @@
 	      case 67:     joy1=0x1000;break;
 	      case 68:     joy1=0x2000;break;
 	      case 90:     joy1=0x4000;break;
+	      case 89:     joy1=0x4000;break;
 	      case 88:     joy1=0x8000;break;
 	      }
 	      if(e.type=="keyup"){


### PR DESCRIPTION
There are some countries such as Germany where the Z and Y keys are switched around: https://en.wikipedia.org/wiki/Keyboard_layout#QWERTZ

To not need to hold your hand in such a weird way, not only Z but also Y is mapped to the Y button.
