### PR TITLE
map key Y (in addition to key Z) to button Y, for international keyboards

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@
 		  </TD>
 		  <TD WIDTH=58 STYLE="border-top: none; border-bottom: 1px solid #000000; border-left: none; border-right: 1px solid #000000; padding-top: 0cm; padding-bottom: 0.1cm; padding-left: 0cm; padding-right: 0.1cm">
 		  <P>
-		    <SPAN >Z
+		    <SPAN >Z/Y
 		    </SPAN>
 		  </P>
 		</TD>

--- a/snes9x.html
+++ b/snes9x.html
@@ -103,6 +103,7 @@
 	      case 67:     joy1=0x1000;break;
 	      case 68:     joy1=0x2000;break;
 	      case 90:     joy1=0x4000;break;
+	      case 89:     joy1=0x4000;break;
 	      case 88:     joy1=0x8000;break;
 	      }
 	      if(e.type=="keyup"){

--- a/snesEmu.html
+++ b/snesEmu.html
@@ -109,6 +109,7 @@
 	      case 67:     joy1=0x1000;break;
 	      case 68:     joy1=0x2000;break;
 	      case 90:     joy1=0x4000;break;
+	      case 89:     joy1=0x4000;break;
 	      case 88:     joy1=0x8000;break;
 	      }
 	      if(e.type=="keyup"){

--- a/snesWW.html
+++ b/snesWW.html
@@ -130,6 +130,7 @@
 	      case 67:     joy1=0x1000;break;
 	      case 68:     joy1=0x2000;break;
 	      case 90:     joy1=0x4000;break;
+	      case 89:     joy1=0x4000;break;
 	      case 88:     joy1=0x8000;break;
 	      }
 	      if(e.type=="keyup"){

--- a/snesWW2.html
+++ b/snesWW2.html
@@ -130,6 +130,7 @@
 	      case 67:     joy1=0x1000;break;
 	      case 68:     joy1=0x2000;break;
 	      case 90:     joy1=0x4000;break;
+	      case 89:     joy1=0x4000;break;
 	      case 88:     joy1=0x8000;break;
 	      }
 	      if(e.type=="keyup"){

--- a/sound4/snes9x.html
+++ b/sound4/snes9x.html
@@ -103,6 +103,7 @@
 	      case 67:     joy1=0x1000;break;
 	      case 68:     joy1=0x2000;break;
 	      case 90:     joy1=0x4000;break;
+	      case 89:     joy1=0x4000;break;
 	      case 88:     joy1=0x8000;break;
 	      }
 	      if(e.type=="keyup"){


### PR DESCRIPTION
There are some countries such as Germany where the Z and Y keys are switched around: https://en.wikipedia.org/wiki/Keyboard_layout#QWERTZ

To not need to hold your hand in such a weird way, not only Z but also Y is mapped to the Y button.
