### PR TITLE
fixed for emscripten 1.38

### DIFF
--- a/snes9x/sdl/buildhtml
+++ b/snes9x/sdl/buildhtml
@@ -6,6 +6,7 @@ INCLUDES="-I. -I.. -I../apu/"
 CCFLAGS="-U__linux -O3 -DLSB_FIRST  -fomit-frame-pointer -fno-exceptions -fno-rtti -pedantic -Wall -W -Wno-unused-parameter -I/usr/include/SDL -D_GNU_SOURCE=1 -D_REENTRANT -DHAVE_MKSTEMP -DHAVE_STRINGS_H -DHAVE_SYS_IOCTL_H -DHAVE_STDINT_H -DRIGHTSHIFT_IS_SAR -Wno-c++11-extensions"
 
 emcc -O3 -s EXPORTED_FUNCTIONS="['_main', '_set_frameskip', '_set_transparency',  '_run',  '_toggle_display_framerate', '_S9xAutoSaveSRAM' ]" \
+ -s "EXTRA_EXPORTED_RUNTIME_METHODS=['ccall', 'cwrap']" \
  -s FORCE_FILESYSTEM=1 \
  --shell-file xnes9x_shell.html \
  -o $OUT/snes9x.html \


### PR DESCRIPTION
I tried compiling with emscripten 1.38.31 and it throws an error on the html page -

> TypeError: Module.cwrap is not a function


For newer versions of emscripten you need add that function as a flag to the emcc compiler. I modified the buildhtml script with the following flags and now it compiles and runs correctly.

> -s "EXTRA_EXPORTED_RUNTIME_METHODS=['ccall', 'cwrap']" 